### PR TITLE
AB#772 - Ensure sockID is valid before indexing the rsi_socket_pool_n…

### DIFF
--- a/sapi/network/socket/rsi_socket.c
+++ b/sapi/network/socket/rsi_socket.c
@@ -3450,7 +3450,9 @@ int32_t rsi_wlan_socket_get_status(int32_t sockID)
  */
 void rsi_wlan_socket_set_status(int32_t status, int32_t sockID)
 {
-  rsi_socket_pool_non_rom[sockID].socket_status = status;
+  if (sockID > 0 && sockID < RSI_NUMBER_OF_SOCKETS) {
+    rsi_socket_pool_non_rom[sockID].socket_status = status;
+  }
 #ifndef RSI_WLAN_STATUS
   rsi_wlan_set_status(status);
 #endif


### PR DESCRIPTION
…on_rom array.